### PR TITLE
Support User Defined Conversions

### DIFF
--- a/argument_parser.h
+++ b/argument_parser.h
@@ -119,5 +119,11 @@ namespace ap {
 
                 return out.str();
             }
+
+            template <typename TModule>
+            void register_module()
+            {
+                m_container.registerModule<TModule>();
+            }
     };
 }


### PR DESCRIPTION
Allows consumers to define their own cdif modules to be used when
looking up conversion functions