### PR TITLE
Implement Simple Error Reporting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "either"]
+	path = either
+	url = git@github.com:aghoward/either.git

--- a/argument.h
+++ b/argument.h
@@ -33,6 +33,11 @@ namespace ap {
                 consumed(false)
         {
         }
+
+        bool is_optional() const
+        {
+            return has_argument || !switches.empty();
+        }
     };
 
     template <typename TIter>

--- a/argument_parser_builder.h
+++ b/argument_parser_builder.h
@@ -22,12 +22,10 @@ namespace ap {
     class ArgumentParserBuilder
     {
         private:
-            std::vector<Argument<TArgs>> m_optional_args;
-            std::vector<Argument<TArgs>> m_positional_args;
+            std::vector<Argument<TArgs>> m_args;
 
             template <typename TMember, typename TFactory>
             auto add_parameter(
-                std::vector<Argument<TArgs>>& arg_list,
                 const std::string& name,
                 const std::vector<std::string>& switches,
                 const std::string& description,
@@ -39,7 +37,7 @@ namespace ap {
                 decltype(std::declval<TFactory>()(std::declval<cdif::Container>())(std::declval<std::string>())),
                 TMember>>
             {
-                arg_list.emplace_back(
+                m_args.emplace_back(
                     name,
                     switches,
                     description,
@@ -60,8 +58,7 @@ namespace ap {
 
         public:
             ArgumentParserBuilder()
-                : m_optional_args(),
-                  m_positional_args()
+                : m_args()
             {
             }
 
@@ -79,7 +76,6 @@ namespace ap {
             ArgumentParserBuilder<TArgs>&>
             {
                 add_parameter(
-                    m_optional_args,
                     name,
                     switches,
                     description,
@@ -115,7 +111,6 @@ namespace ap {
             ArgumentParserBuilder<TArgs>&>
             {
                 add_parameter(
-                    m_positional_args,
                     name,
                     {},
                     description,
@@ -139,7 +134,7 @@ namespace ap {
 
             ArgumentParser<TArgs> build() const
             {
-                return ArgumentParser<TArgs>(m_optional_args, m_positional_args);
+                return ArgumentParser<TArgs>(m_args);
             }
     };
 }

--- a/errors.h
+++ b/errors.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace ap {
+    enum class ParsingError {
+        UnknownArgument,
+        MissingPositionalArgument,
+        TooManyPositionalArguments,
+        MissingValueForArgument
+    };
+}


### PR DESCRIPTION
Previously the api returned an empty `std::optional` on error which
didn't report any information about why the parsing failed. This returns
an `either<TArgs, ParsingError>` and exposes a `get_error_message`
function to inform the user of why the command failed.