### PR TITLE
Freestanding optional args

### DIFF
--- a/argument.h
+++ b/argument.h
@@ -18,20 +18,23 @@ namespace ap {
         std::function<void (const cdif::Container&, TArgs&, const std::string&)> parser;
 
         bool consumed;
+        bool freestanding;
 
         Argument(
             const std::string& _name,
             const std::vector<std::string>& _switches,
             const std::string& _description,
             bool _has_argument,
-            std::function<void (const cdif::Container&, TArgs&, const std::string&)> _parser)
+            std::function<void (const cdif::Container&, TArgs&, const std::string&)> _parser,
+            bool _freestanding)
             :
                 name(_name),
                 switches(_switches),
                 description(_description),
                 has_argument(_has_argument),
                 parser(_parser),
-                consumed(false)
+                consumed(false),
+                freestanding(_freestanding)
         {
         }
 

--- a/argument.h
+++ b/argument.h
@@ -61,7 +61,7 @@ namespace ap {
         if (!arg.switches.empty())
             join(ss, arg.switches.begin(), arg.switches.end(), "|");
 
-        if (arg.has_argument)
+        if (arg.has_argument || !arg.is_optional())
             ss << " <" << arg.name << ">";
         return ss.str();
     }

--- a/argument_parser_builder.h
+++ b/argument_parser_builder.h
@@ -32,7 +32,8 @@ namespace ap {
                 bool hasArgument,
                 TMember TArgs::*member,
                 TMember defaultValue,
-                TFactory&& conversion_factory)
+                TFactory&& conversion_factory,
+                bool freestanding)
             -> std::enable_if_t<std::is_convertible_v<
                 decltype(std::declval<TFactory>()(std::declval<cdif::Container>())(std::declval<std::string>())),
                 TMember>>
@@ -52,7 +53,8 @@ namespace ap {
                             auto conversion = conversion_factory(ctx);
                             args.*member = input.empty() ? defaultValue : conversion(input);
                         }
-                    });
+                    },
+                    freestanding);
             }
 
 
@@ -69,7 +71,8 @@ namespace ap {
                 TMember defaultValue,
                 const std::vector<std::string>& switches,
                 const std::string& description,
-                TFactory&& conversion_factory)
+                TFactory&& conversion_factory,
+                bool freestanding = false)
             -> std::enable_if_t<std::is_convertible_v<
                 decltype(std::declval<TFactory>()(std::declval<cdif::Container>())(std::declval<std::string>())),
                 TMember>,
@@ -82,7 +85,8 @@ namespace ap {
                     !std::is_same_v<TMember, bool>,
                     member,
                     defaultValue,
-                    conversion_factory);
+                    conversion_factory,
+                    freestanding);
 
                 return *this;
             }
@@ -93,9 +97,10 @@ namespace ap {
                 TMember TArgs::*member,
                 TMember defaultValue,
                 const std::vector<std::string>& switches,
-                const std::string& description)
+                const std::string& description,
+                bool freestanding = false)
             {
-                return add_optional(name, member, defaultValue, switches, description, impl::default_conversion_factory<TMember>);
+                return add_optional(name, member, defaultValue, switches, description, impl::default_conversion_factory<TMember>, freestanding);
             }
 
             template <typename TMember, typename TFactory>
@@ -117,7 +122,8 @@ namespace ap {
                     false,
                     member,
                     defaultValue,
-                    conversion_factory);
+                    conversion_factory,
+                    false);
 
                 return *this;
             }

--- a/errors.h
+++ b/errors.h
@@ -5,6 +5,7 @@ namespace ap {
         UnknownArgument,
         MissingPositionalArgument,
         TooManyPositionalArguments,
-        MissingValueForArgument
+        MissingValueForArgument,
+        TooManyIndependentArguments
     };
 }


### PR DESCRIPTION
Allow freestanding optional arguments that override other requirements for providing positional arguments and arguments for optionals.

Also fixes a bug whereby positional arguments didn't display their names in the help text